### PR TITLE
Test

### DIFF
--- a/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplayChangedEventArgsTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplayChangedEventArgsTests.cs
@@ -6,6 +6,7 @@ namespace VelaptorTests.NativeInterop.GLFW;
 
 using Velaptor.NativeInterop.GLFW;
 using Xunit;
+using FluentAssertions;
 
 public class GlfwDisplayChangedEventArgsTests
 {
@@ -17,7 +18,7 @@ public class GlfwDisplayChangedEventArgsTests
         var eventArgs = new GlfwDisplayChangedEventArgs(true);
 
         // Assert
-        Assert.True(eventArgs.IsConnected);
+        eventArgs.IsConnected.Should().BeTrue();
     }
     #endregion
 }

--- a/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplaysTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplaysTests.cs
@@ -16,7 +16,6 @@ using Velaptor.NativeInterop.GLFW;
 using Xunit;
 using FluentAssertions;
 
-
 /// <summary>
 /// Tests the <see cref="GlfwDisplays"/> class.
 /// </summary>

--- a/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplaysTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/GLFW/GlfwDisplaysTests.cs
@@ -8,13 +8,14 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
-using Helpers;
 using Moq;
 using Silk.NET.GLFW;
 using Velaptor;
 using Velaptor.Hardware;
 using Velaptor.NativeInterop.GLFW;
 using Xunit;
+using FluentAssertions;
+
 
 /// <summary>
 /// Tests the <see cref="GlfwDisplays"/> class.
@@ -93,21 +94,21 @@ public unsafe class GlfwDisplaysTests
     [Fact]
     public void Ctor_WithNullGLFWInvokerParam_ThrowsException()
     {
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<ArgumentNullException>(() =>
-        {
-            _ = new GlfwDisplays(null, this.mockPlatform.Object);
-        }, "The parameter must not be null. (Parameter 'glfwInvoker')");
+        // Arrange & Act
+        var act = () => new GlfwDisplays(null, this.mockPlatform.Object);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithMessage("The parameter must not be null. (Parameter 'glfwInvoker')");
     }
 
     [Fact]
     public void Ctor_WithNullPlatformParam_ThrowsException()
     {
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<ArgumentNullException>(() =>
-        {
-            _ = new GlfwDisplays(this.mockGlfwInvoker.Object, null);
-        }, "The parameter must not be null. (Parameter 'platform')");
+        // Arrange & Act
+        var act = () => new GlfwDisplays(this.mockGlfwInvoker.Object, null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithMessage("The parameter must not be null. (Parameter 'platform')");
     }
 
     [Fact]
@@ -165,8 +166,7 @@ public unsafe class GlfwDisplaysTests
         var actual = displays.SystemDisplays;
 
         // Assert
-        Assert.Equal(expectedDisplayA, actual[0]);
-        Assert.Equal(expectedDisplayB, actual[1]);
+        actual.Should().HaveCount(2).And.ContainInOrder(expectedDisplayA, expectedDisplayB);
     }
     #endregion
 
@@ -186,7 +186,7 @@ public unsafe class GlfwDisplaysTests
             => e.OnDisplayChanged += null, new GlfwDisplayChangedEventArgs(true));
 
         // Assert
-        Assert.True(refreshInvoked);
+        refreshInvoked.Should().BeTrue();
     }
 
     [Fact]

--- a/Testing/VelaptorTests/NativeInterop/GLFW/GlfwErrorEventArgsTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/GLFW/GlfwErrorEventArgsTests.cs
@@ -6,7 +6,6 @@ namespace VelaptorTests.NativeInterop.GLFW;
 
 using System;
 using FluentAssertions;
-using Helpers;
 using Velaptor.NativeInterop.GLFW;
 using Xunit;
 
@@ -18,11 +17,11 @@ public class GlfwErrorEventArgsTests
     [InlineData(null)]
     public void Ctor_WithNullOrEmptyErrorMessageParam_ThrowsException(string message)
     {
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<ArgumentNullException>(() =>
-        {
-            _ = new GlfwErrorEventArgs(GlfwErrorCode.NoError, message);
-        }, "The string parameter must not be null or empty. (Parameter 'errorMessage')");
+        // Act
+        var act = () => new GlfwErrorEventArgs(GlfwErrorCode.NoError, message);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithMessage("The string parameter must not be null or empty. (Parameter 'errorMessage')");
     }
 
     [Fact]

--- a/Testing/VelaptorTests/NativeInterop/GLFW/GlfwErrorEventArgsTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/GLFW/GlfwErrorEventArgsTests.cs
@@ -17,7 +17,7 @@ public class GlfwErrorEventArgsTests
     [InlineData(null)]
     public void Ctor_WithNullOrEmptyErrorMessageParam_ThrowsException(string message)
     {
-        // Act
+        // Arrange & Act
         var act = () => new GlfwErrorEventArgs(GlfwErrorCode.NoError, message);
 
         // Assert

--- a/Testing/VelaptorTests/NativeInterop/OpenGL/OpenGLServiceTests.cs
+++ b/Testing/VelaptorTests/NativeInterop/OpenGL/OpenGLServiceTests.cs
@@ -7,11 +7,11 @@ namespace VelaptorTests.NativeInterop.OpenGL;
 using System;
 using System.Drawing;
 using System.Numerics;
-using Helpers;
 using Moq;
 using Velaptor.NativeInterop.OpenGL;
 using Velaptor.OpenGL;
 using Xunit;
+using FluentAssertions;
 
 /// <summary>
 /// Tests the <see cref="OpenGLService"/> class.
@@ -47,13 +47,14 @@ public class OpenGLServiceTests
     [Fact]
     public void Ctor_WithNullGLInvokerParam_ThrowsException()
     {
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<ArgumentNullException>(() =>
-        {
-            _ = new OpenGLService(null);
-        }, "The parameter must not be null. (Parameter 'glInvoker')");
+        // Arrange & Act
+        var act = () => new OpenGLService(null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithMessage("The parameter must not be null. (Parameter 'glInvoker')");
     }
     #endregion
+
     #region Prop Tests
     [Fact]
     public void IsVBOBound_WhenGettingValue_ReturnsCorrectResult()
@@ -68,8 +69,8 @@ public class OpenGLServiceTests
         var isUnbound = service.IsVBOBound;
 
         // Assert
-        Assert.True(isBound);
-        Assert.False(isUnbound);
+        isBound.Should().BeTrue();
+        isUnbound.Should().BeFalse();
     }
 
     [Fact]
@@ -85,8 +86,8 @@ public class OpenGLServiceTests
         var isUnbound = service.IsEBOBound;
 
         // Assert
-        Assert.True(isBound);
-        Assert.False(isUnbound);
+        isBound.Should().BeTrue();
+        isUnbound.Should().BeFalse();
     }
 
     [Fact]
@@ -102,8 +103,8 @@ public class OpenGLServiceTests
         var isUnbound = service.IsVAOBound;
 
         // Assert
-        Assert.True(isBound);
-        Assert.False(isUnbound);
+        isBound.Should().BeTrue();
+        isUnbound.Should().BeFalse();
     }
     #endregion
 
@@ -118,7 +119,7 @@ public class OpenGLServiceTests
         var actual = service.GetViewPortSize();
 
         // Assert
-        Assert.Equal(new Size(33, 44), actual);
+        actual.Should().BeEquivalentTo(new Size(33, 44));
     }
 
     [Fact]
@@ -144,7 +145,7 @@ public class OpenGLServiceTests
         var actual = service.GetViewPortPosition();
 
         // Assert
-        Assert.Equal(new Vector2(11, 22), actual);
+        actual.Should().BeEquivalentTo(new Vector2(11, 22));
     }
 
     [Fact]
@@ -193,11 +194,11 @@ public class OpenGLServiceTests
         var service = CreateService();
         service.BindVAO(123u);
 
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<InvalidOperationException>(() =>
-        {
-            service.UnbindEBO();
-        }, "The VAO object must be unbound before unbinding an EBO object.");
+        // Act
+        var act = service.UnbindEBO;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("The VAO object must be unbound before unbinding an EBO object.");
     }
 
     [Fact]
@@ -281,7 +282,7 @@ public class OpenGLServiceTests
         var actual = service.ProgramLinkedSuccessfully(123);
 
         // Assert
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Theory]
@@ -300,7 +301,7 @@ public class OpenGLServiceTests
         var actual = service.ShaderCompiledSuccessfully(123);
 
         // Assert
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Fact]
@@ -385,11 +386,11 @@ public class OpenGLServiceTests
         exceptionMsg += $"(Parameter 'bufferType'){Environment.NewLine}Actual value was 123.";
         var service = CreateService();
 
-        // Act & Assert
-        AssertExtensions.ThrowsWithMessage<ArgumentOutOfRangeException>(() =>
-        {
-            service.LabelBuffer(It.IsAny<uint>(), It.IsAny<string>(), (OpenGLBufferType)123);
-        }, exceptionMsg);
+        // Act
+        var act = () => service.LabelBuffer(It.IsAny<uint>(), It.IsAny<string>(), (OpenGLBufferType)123);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage(exceptionMsg);
     }
 
     [Theory]


### PR DESCRIPTION
Refactored unit test assertions on the following files:

-  GLFWErrorEventArgsTests.cs - 37 lines
-  GLFWDisplayChangedEventArgsTests.cs - 22 lines
-  GLFWDisplayTests.cs - 211 lines
-  OpenGLServiceTests.cs - 439 lines

Removed xUnit assertions and replaced them with FluentAssertions wherever it was possible.