### PR TITLE
Fix docs release announcement gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate_branch, get_and_validate_version, determine_release_notes_path, build, run_tests, run_release]
     if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false && inputs.trigger-docs-release == true }}
+    outputs:
+      dispatched-at: ${{ steps.execute-release.outputs.dispatched-at }}
     steps:
       - name: Execute Release
+        id: execute-release
         env:
           VERSION: "v${{ needs.get_and_validate_version.outputs.version }}"
           GH_TOKEN: ${{ secrets.CICD_TOKEN }}
@@ -177,14 +180,57 @@ jobs:
           $repoName = "${{ vars.VELAPTOR_DOCS_REPO_NAME }}";
           $docSiteReleaseBranch = "${{ vars.DOC_SITE_RELEASE_BRANCH }}";
           $version = $env:VERSION;
+          $dispatchedAt = (Get-Date).ToUniversalTime().ToString("o");
+
+          "dispatched-at=$dispatchedAt" >> $env:GITHUB_OUTPUT;
 
           gh workflow run $workflowName -R "$orgName/$repoName" --ref "$docSiteReleaseBranch" --field "api-version=$version" --field "executed-externally=true";
+
+
+  gate_velaptor_docs_release:
+    name: Gate Velaptor Docs Release
+    runs-on: ubuntu-latest
+    needs: [release_velaptor_docs]
+    if: ${{ always() }}
+    steps:
+      - name: Skip Docs Release Gate
+        if: ${{ inputs.release-type != 'Production' || inputs.dry-run == true || inputs.trigger-docs-release == false }}
+        run: Write-Host "Docs release gate skipped because the release does not trigger VelaptorDocs."
+
+      - name: Fail If Docs Dispatch Failed
+        if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false && inputs.trigger-docs-release == true && needs.release_velaptor_docs.result != 'success' }}
+        run: |
+          Write-Error "The VelaptorDocs workflow dispatch did not complete successfully. Blocking release announcements.";
+          exit 1;
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false && inputs.trigger-docs-release == true && needs.release_velaptor_docs.result == 'success' }}
+
+      - name: Set Up Deno (${{ vars.DENO_VERSION }})
+        if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false && inputs.trigger-docs-release == true && needs.release_velaptor_docs.result == 'success' }}
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 #v2.0.4
+        with:
+          deno-version: "${{ vars.DENO_VERSION }}"
+
+      - name: Wait For Velaptor Docs Release
+        if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false && inputs.trigger-docs-release == true && needs.release_velaptor_docs.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.CICD_TOKEN }}
+        run: |
+          deno run --allow-env --allow-net=api.github.com ./DevTools/wait-for-workflow.ts `
+            --owner "${{ vars.ORGANIZATION_NAME }}" `
+            --repo "${{ vars.VELAPTOR_DOCS_REPO_NAME }}" `
+            --workflow "${{ vars.VELAPTOR_DOCS_FULL_RELEASE_WORKFLOW_NAME }}" `
+            --branch "${{ vars.DOC_SITE_RELEASE_BRANCH }}" `
+            --started-after "${{ needs.release_velaptor_docs.outputs.dispatched-at }}" `
+            --max-attempts "60" `
+            --delay-seconds "60";
 
 
   send_release_announcements:
     name: Send Release Announcements
     runs-on: ubuntu-latest
-    needs: [validate_branch, get_and_validate_version, determine_release_notes_path, build, run_tests, run_release]
+    needs: [validate_branch, get_and_validate_version, determine_release_notes_path, build, run_tests, run_release, gate_velaptor_docs_release]
     if: ${{ inputs.release-type == 'Production' && inputs.dry-run == false }}
     steps:
       - name: Send X Release Announcement

--- a/DevTools/wait-for-workflow.ts
+++ b/DevTools/wait-for-workflow.ts
@@ -1,0 +1,267 @@
+type Workflow = {
+	id: number;
+	name: string;
+	path: string;
+	state: string;
+};
+
+type WorkflowsResponse = {
+	workflows: Workflow[];
+};
+
+type WorkflowRun = {
+	id: number;
+	status: string;
+	conclusion: string | null;
+	created_at: string;
+	html_url: string;
+	head_branch: string;
+	event: string;
+};
+
+type WorkflowRunsResponse = {
+	workflow_runs: WorkflowRun[];
+};
+
+type ScriptArgs = {
+	owner: string;
+	repo: string;
+	workflow: string;
+	branch: string;
+	startedAfter: Date;
+	maxAttempts: number;
+	delaySeconds: number;
+};
+
+const terminalSuccessConclusion = "success";
+
+const sleep = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const parseCliArgs = (): Map<string, string> => {
+	const parsedArgs = new Map<string, string>();
+
+	for (let i = 0; i < Deno.args.length; i++) {
+		const arg = Deno.args[i];
+
+		if (!arg.startsWith("--")) {
+			continue;
+		}
+
+		const key = arg.slice(2);
+		const nextArg = Deno.args[i + 1];
+
+		if (nextArg === undefined || nextArg.startsWith("--")) {
+			parsedArgs.set(key, "true");
+			continue;
+		}
+
+		parsedArgs.set(key, nextArg);
+		i++;
+	}
+
+	return parsedArgs;
+};
+
+const requiredArg = (args: Map<string, string>, name: string): string => {
+	const value = args.get(name)?.trim() ?? "";
+
+	if (value.length === 0) {
+		console.error(`Missing required argument '--${name}'.`);
+		Deno.exit(1);
+	}
+
+	return value;
+};
+
+const parsePositiveInt = (
+	args: Map<string, string>,
+	name: string,
+	defaultValue: number,
+): number => {
+	const rawValue = args.get(name)?.trim() ?? defaultValue.toString();
+	const parsedValue = Number(rawValue);
+
+	if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+		console.error(`Argument '--${name}' must be a positive whole number.`);
+		Deno.exit(1);
+	}
+
+	return parsedValue;
+};
+
+const parseScriptArgs = (): ScriptArgs => {
+	const args = parseCliArgs();
+	const startedAfterValue = requiredArg(args, "started-after");
+	const startedAfter = new Date(startedAfterValue);
+
+	if (Number.isNaN(startedAfter.getTime())) {
+		console.error("Argument '--started-after' must be a valid ISO 8601 date.");
+		Deno.exit(1);
+	}
+
+	return {
+		owner: requiredArg(args, "owner"),
+		repo: requiredArg(args, "repo"),
+		workflow: requiredArg(args, "workflow"),
+		branch: requiredArg(args, "branch"),
+		startedAfter: startedAfter,
+		maxAttempts: parsePositiveInt(args, "max-attempts", 60),
+		delaySeconds: parsePositiveInt(args, "delay-seconds", 60),
+	};
+};
+
+const getToken = (): string => {
+	const token = (Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN") ?? "")
+		.trim();
+
+	if (token.length === 0) {
+		console.error("The 'GH_TOKEN' or 'GITHUB_TOKEN' environment variable is required.");
+		Deno.exit(1);
+	}
+
+	return token;
+};
+
+const requestJson = async <T>(url: URL, token: string): Promise<T> => {
+	const response = await fetch(url, {
+		headers: {
+			Accept: "application/vnd.github+json",
+			Authorization: `Bearer ${token}`,
+			"User-Agent": "KinsonDigital-Velaptor-Release-Gate",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+	});
+
+	if (!response.ok) {
+		const responseBody = await response.text();
+		throw new Error(
+			`GitHub API request failed (${response.status} ${response.statusText}): ${responseBody}`,
+		);
+	}
+
+	return await response.json() as T;
+};
+
+const normalize = (value: string): string => value.trim().toLowerCase();
+
+const getFileName = (path: string): string => {
+	const parts = path.split("/");
+
+	return parts[parts.length - 1] ?? path;
+};
+
+const findWorkflow = async (
+	args: ScriptArgs,
+	token: string,
+): Promise<Workflow> => {
+	const workflowsUrl = new URL(
+		`https://api.github.com/repos/${args.owner}/${args.repo}/actions/workflows`,
+	);
+	workflowsUrl.searchParams.set("per_page", "100");
+
+	const response = await requestJson<WorkflowsResponse>(workflowsUrl, token);
+	const target = normalize(args.workflow);
+	const workflow = response.workflows.find((currentWorkflow) => {
+		const workflowCandidates = [
+			currentWorkflow.id.toString(),
+			currentWorkflow.name,
+			currentWorkflow.path,
+			getFileName(currentWorkflow.path),
+		];
+
+		return workflowCandidates.some((candidate) => normalize(candidate) === target);
+	});
+
+	if (workflow === undefined) {
+		throw new Error(
+			`Could not find workflow '${args.workflow}' in '${args.owner}/${args.repo}'.`,
+		);
+	}
+
+	if (workflow.state !== "active") {
+		throw new Error(
+			`Workflow '${workflow.name}' exists, but its state is '${workflow.state}'.`,
+		);
+	}
+
+	return workflow;
+};
+
+const getLatestRun = async (
+	args: ScriptArgs,
+	token: string,
+	workflow: Workflow,
+): Promise<WorkflowRun | undefined> => {
+	const workflowRunsUrl = new URL(
+		`https://api.github.com/repos/${args.owner}/${args.repo}/actions/workflows/${workflow.id}/runs`,
+	);
+	workflowRunsUrl.searchParams.set("branch", args.branch);
+	workflowRunsUrl.searchParams.set("event", "workflow_dispatch");
+	workflowRunsUrl.searchParams.set("per_page", "10");
+
+	const response = await requestJson<WorkflowRunsResponse>(workflowRunsUrl, token);
+	const matchingRuns = response.workflow_runs
+		.filter((run) => new Date(run.created_at) >= args.startedAfter)
+		.sort((firstRun, secondRun) =>
+			new Date(secondRun.created_at).getTime() -
+			new Date(firstRun.created_at).getTime()
+		);
+
+	return matchingRuns[0];
+};
+
+const run = async () => {
+	const args = parseScriptArgs();
+	const token = getToken();
+	const workflow = await findWorkflow(args, token);
+	const delayMilliseconds = args.delaySeconds * 1000;
+
+	console.log(
+		`Watching '${workflow.name}' in '${args.owner}/${args.repo}' on branch '${args.branch}'.`,
+	);
+	console.log(`Ignoring runs created before ${args.startedAfter.toISOString()}.`);
+
+	for (let attempt = 1; attempt <= args.maxAttempts; attempt++) {
+		console.log(
+			`Checking docs release workflow status (attempt ${attempt} of ${args.maxAttempts})...`,
+		);
+
+		const latestRun = await getLatestRun(args, token, workflow);
+
+		if (latestRun === undefined) {
+			console.log(
+				`No matching workflow run found yet. Waiting ${args.delaySeconds} seconds before retrying.`,
+			);
+			await sleep(delayMilliseconds);
+			continue;
+		}
+
+		console.log(
+			`Latest run: ${latestRun.html_url} status=${latestRun.status} conclusion=${latestRun.conclusion ?? "none"}`,
+		);
+
+		if (latestRun.status === "completed") {
+			if (latestRun.conclusion === terminalSuccessConclusion) {
+				console.log("Docs release workflow completed successfully.");
+				return;
+			}
+
+			console.error(
+				`Docs release workflow finished with conclusion '${latestRun.conclusion}'.`,
+			);
+			Deno.exit(1);
+		}
+
+		console.log(
+			`Docs release workflow is still '${latestRun.status}'. Waiting ${args.delaySeconds} seconds before retrying.`,
+		);
+		await sleep(delayMilliseconds);
+	}
+
+	console.error(
+		`Timed out waiting for docs release workflow after ${args.maxAttempts} attempts.`,
+	);
+	Deno.exit(1);
+};
+
+await run();


### PR DESCRIPTION
## Summary
- adds a Deno GitHub API polling script for workflow runs
- records the VelaptorDocs dispatch timestamp and waits for the matching docs release run
- blocks release announcements when docs dispatch fails, docs release fails, or docs release times out
- keeps the gate skipped for preview, dry-run, and trigger-docs-release=false releases

Closes #1199.

## Verification
- `deno fmt --check DevTools/wait-for-workflow.ts`
- `deno lint DevTools/wait-for-workflow.ts`
- `deno check DevTools/wait-for-workflow.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/release.yml`\n- live API smoke test: `GH_TOKEN="$(gh auth token)" deno run --allow-env --allow-net=api.github.com ./DevTools/wait-for-workflow.ts --owner KinsonDigital --repo Velaptor --workflow unit-test-status-check.yml --branch preview --started-after 2026-01-01T00:00:00Z --max-attempts 1 --delay-seconds 1`\n\nNote: repo-wide `deno fmt --check` and `deno lint` currently fail on existing DevTools files outside this patch under local Deno 2.7.14, so I kept verification scoped to the new script and workflow syntax.